### PR TITLE
商品一覧表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
-
-    #@items = Item.includes(:user).all
+    @items = Item.includes(:user).all
   end 
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index]
   def index
-    @items = Item.includes(:user).all
+    @items = Item.all.order(created_at: :desc)
   end 
 
   def new

--- a/app/models/Location.rb
+++ b/app/models/Location.rb
@@ -1,5 +1,5 @@
 # app/models/prefecture.rb
-class Prefecture < ActiveHash::Base
+class Location < ActiveHash::Base
   self.data = [
     { id: 1, name: '---' },
     { id: 2, name: '北海道' },

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,7 +6,7 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :condition
   belongs_to :shipping_fee
-  belongs_to :prefecture
+  belongs_to :Location
   belongs_to :shipping_day
   
   # バリデーション

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -145,10 +145,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,11 +128,9 @@
     </div>
     <ul class='item-lists'>
   <% if @items.present? %>
-  <%# 商品があるときにだけループを回す %>
     <% @items.each do |item| %>
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to item_path(item) do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
@@ -157,11 +155,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
     <% end %>
   <% else %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -180,8 +175,6 @@
         <% end %>
       </li>
   <% end %>  
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,12 +127,14 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
+  <% if @items.present? %>
+  <%# 商品があるときにだけループを回す %>
+    <% @items.each do |item| %>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -156,7 +158,8 @@
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+    <% end %>
+  <% else %>
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -176,6 +179,7 @@
         </div>
         <% end %>
       </li>
+  <% end %>  
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -74,7 +74,7 @@
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:location_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:location_id, Location.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>


### PR DESCRIPTION
What（何を実装したか？）
商品一覧表示機能 を実装しました。
データベースに登録された商品の一覧を表示

Why（なぜこの実装が必要か？）
ユーザーが出品された商品を一覧で確認できるようにするため。
出品された商品の新着順での表示を可能にすることで、ユーザーが最新の商品を簡単に確認できるようにするため。

# プルリクエストへ記載するgyazo
商品のデータがない場合は、ダミー商品が表示されている動画
URL：
https://gyazo.com/7c2793c55dc4805c6102b6f2adcc63c1
商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
URL：※更新
https://gyazo.com/71c8fef84563578163b5f0b27f403f9b