### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :show, :update]  
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :redirect_unless_owner, only: [:edit, :update]
+  before_action :redirect_unless_owner, only: [:edit, :update, :destroy]
 
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :show, :update]  
+  before_action :set_item, only: [:edit, :show, :update, :destroy]  
   before_action :authenticate_user!, except: [:index, :show]
   before_action :redirect_unless_owner, only: [:edit, :update, :destroy]
 
@@ -37,11 +37,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
-    if @item.destroy
+    if @item.destroy  
       redirect_to root_path, notice: "商品を削除しました"
     else
-      redirect_to root_path, alert: "商品を削除できませんでした"    
+      redirect_to root_path, alert: "商品を削除できませんでした"
+    end
   end
   
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -41,8 +41,7 @@ class ItemsController < ApplicationController
     if @item.destroy
       redirect_to root_path, notice: "商品を削除しました"
     else
-      render :edit, status: :unprocessable_entity
-    end
+      redirect_to root_path, alert: "商品を削除できませんでした"    
   end
   
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,10 +25,8 @@ class ItemsController < ApplicationController
   end
 
   def edit
-
   end
 
-  end
 
   def update
     if @item.update(item_params)  
@@ -37,6 +35,16 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
+  def destroy
+    @item = Item.find(params[:id])
+    if @item.destroy
+      redirect_to root_path, notice: "商品を削除しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+  
 
   private
   def item_params

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
     <%# 自分が出品した商品 %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: { turbo_method: :delete, confirm: "本当に削除しますか？" }, class: "item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete, confirm: "本当に削除しますか？" }, class: "item-destroy" %>
   <% else %>
     <%# 他のユーザーの商品（購入ボタンを表示） %>
     <%= link_to "購入画面に進む", "#", class: "item-red-btn" %>


### PR DESCRIPTION

##What（このプルリクエストの変更内容）##
商品削除機能を実装
出品者のみが商品を削除できるように実装

##Why（この変更をする理由）##
出品者が不要になった商品を削除できるようにするため
他のユーザーが勝手に商品を削除できないよう、適切な権限管理を行うため


##プルリクエストへ記載するgyazo##
-ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
URL：https://gyazo.com/754e2ff9e43185fb8e0c17dd0c12f92a